### PR TITLE
chore: modernize gradle configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,12 @@
-apply plugin: 'com.android.application'
-apply plugin: 'com.google.gms.google-services'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'com.github.ben-manes.versions'
-apply plugin: 'com.getkeepsafe.dexcount'
-apply plugin: 'com.vanniktech.android.junit.jacoco'
-apply plugin: 'io.fabric'
-apply plugin: 'com.google.firebase.firebase-perf'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.kapt'
+    id 'com.github.ben-manes.versions'
+    id 'com.getkeepsafe.dexcount'
+    id 'com.vanniktech.android.junit.jacoco'
+    id 'com.google.firebase.firebase-perf'
+}
 
 ext {
 
@@ -17,12 +16,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    namespace "co.netguru.baby.monitor.client"
+    compileSdk 34
     defaultConfig {
         applicationId "com.netguru.babyguard"
-        minSdkVersion 21
-        targetSdkVersion 29
+        minSdk 21
+        targetSdk 34
         versionCode isBitrise ? Integer.parseInt(bitrise.io.buildNumber) : 1
         versionName '0.5.0'
         vectorDrawables.useSupportLibrary = true
@@ -36,10 +35,10 @@ android {
         debug {
             versionNameSuffix "-DEBUG"
             applicationIdSuffix ".debug"
-            testCoverageEnabled true
-            debuggable true
-            minifyEnabled false
-            shrinkResources false
+            enableUnitTestCoverage true
+            isDebuggable = true
+            isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles getDefaultProguardFile('proguard-android.txt'),
                     'proguard-rules.pro', 'proguard-instant-run.pro', 'proguard-rules-test.pro'
         }
@@ -47,18 +46,18 @@ android {
             signingConfig signingConfigs.debug
             versionNameSuffix "-PREPROD"
             applicationIdSuffix ".preprod"
-            debuggable true
-            minifyEnabled true
-            shrinkResources true
-            zipAlignEnabled true
+            isDebuggable = true
+            isMinifyEnabled = true
+            isShrinkResources = true
+            isZipAlignEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                     'proguard-rules-release-preprod.pro'
         }
         release {
-            debuggable false
-            minifyEnabled true
-            shrinkResources true
-            zipAlignEnabled true
+            isDebuggable = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            isZipAlignEnabled = true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                     'proguard-rules-release.pro'
         }
@@ -80,9 +79,11 @@ android {
         }
     }
     packagingOptions {
-        exclude 'META-INF/services/javax.annotation.processing.Processor'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/NOTICE.txt'
+        resources {
+            excludes += ['META-INF/services/javax.annotation.processing.Processor',
+                          'META-INF/LICENSE.txt',
+                          'META-INF/NOTICE.txt']
+        }
     }
     sourceSets.all {
         it.java.srcDir "src/$it.name/kotlin"
@@ -109,27 +110,23 @@ android {
                     '**/*Lambda.class',
                     '**/*Lambda*.class']
     }
-    lintOptions {
-        abortOnError false
+    lint {
+        abortOnError = false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
-        jvmTarget = 1.8
+        jvmTarget = '17'
     }
 }
 
 kapt {
     correctErrorTypes = true
-}
-
-androidExtensions {
-    experimental = true
 }
 
 configurations {
@@ -146,6 +143,8 @@ configurations {
         }
     }
 }
+
+apply plugin: 'com.google.gms.google-services'
 
 dependencies {
     //Kotlin

--- a/build.gradle
+++ b/build.gradle
@@ -2,26 +2,22 @@
 buildscript {
 
     ext {
-        kotlinVersion = '1.3.61'
+        kotlinVersion = '1.9.22'
     }
     repositories {
         google()
-        jcenter()
         mavenCentral()
-        mavenLocal()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://maven.fabric.io/public' }
+        gradlePluginPortal()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath "com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6"
-        classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.15.0'
+        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:4.0.0'
+        classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.18.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.25.0'
-        classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.31.2'
-        classpath 'com.google.firebase:perf-plugin:1.3.1'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.51.0'
+        classpath 'com.google.gms:google-services:4.4.1'
+        classpath 'com.google.firebase:perf-plugin:1.4.2'
     }
 }
 
@@ -52,11 +48,9 @@ tasks.register('detektAll', io.gitlab.arturbosch.detekt.Detekt) {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url "https://clojars.org/repo/" }
-        maven { url "https://maven.fabric.io/public" }
     }
 }
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -43,7 +43,7 @@ ext {
             firebaseMessaging   : 'com.google.firebase:firebase-messaging:20.0.1',
             firebaseAnalytics   : 'com.google.firebase:firebase-analytics:17.2.1',
             firebasePerformance : 'com.google.firebase:firebase-perf:19.0.4',
-            crashlytics         : 'com.crashlytics.sdk.android:crashlytics:2.10.1',
+            crashlytics         : 'com.google.firebase:firebase-crashlytics:18.6.1',
             okHttp              : "com.squareup.okhttp3:okhttp:$okHttpVersion",
             deviceNames         : "com.jaredrummler:android-device-names:1.1.9"
     ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Mar 29 11:22:03 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip


### PR DESCRIPTION
## Summary
- upgrade the Gradle wrapper to 8.6 and bump buildscript plugin versions for Kotlin, AGP, and Firebase tooling
- migrate the app module to the plugins DSL, raise compile/target SDK to 34, and update DSL usage for lint, packaging, and coverage
- switch Crashlytics to the Firebase artifact now that Fabric repositories are removed and add the required namespace declaration

## Testing
- `./gradlew wrapper --gradle-version 8.6 --distribution-type all` *(fails: HTTP 403 Forbidden while downloading Gradle distribution through the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d704446a3c832390a11799ca621cde