### PR TITLE
Migrate to Firebase Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.getkeepsafe.dexcount'
 apply plugin: 'com.vanniktech.android.junit.jacoco'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.firebase.firebase-perf'
 
 ext {
@@ -223,7 +223,8 @@ dependencies {
     //WebRtc
     implementation libs.googleWebRtc
 
-    //Firebase Storage
+    //Firebase
+    implementation platform('com.google.firebase:firebase-bom:33.1.0')
     implementation libs.firebaseStorage
 
     //Firebase Database
@@ -235,7 +236,7 @@ dependencies {
 
     //Firebase Analytics
     implementation libs.firebaseAnalytics
-    implementation libs.crashlytics
+    implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation libs.firebasePerformance
 
     implementation libs.deviceNames

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/client/RtcClient.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/webrtc/client/RtcClient.kt
@@ -11,7 +11,7 @@ import co.netguru.baby.monitor.client.feature.communication.webrtc.base.RtcMessa
 import co.netguru.baby.monitor.client.feature.communication.webrtc.observers.ConnectionObserver
 import co.netguru.baby.monitor.client.feature.communication.webrtc.observers.DefaultSdpObserver
 import co.netguru.baby.monitor.client.feature.communication.websocket.Message
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import io.reactivex.Completable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -85,7 +85,7 @@ class RtcClient(
                         remoteAudioTrack = mediaStream.audioTracks[0]
                     }
                 } catch (e: Exception) {
-                    Crashlytics.logException(e)
+                    FirebaseCrashlytics.getInstance().recordException(e)
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         mavenCentral()
         mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
@@ -20,7 +19,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.25.0'
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.31.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
         classpath 'com.google.firebase:perf-plugin:1.3.1'
     }
 }
@@ -56,7 +55,6 @@ allprojects {
         mavenCentral()
         maven { url "https://jitpack.io" }
         maven { url "https://clojars.org/repo/" }
-        maven { url "https://maven.fabric.io/public" }
     }
 }
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -43,7 +43,6 @@ ext {
             firebaseMessaging   : 'com.google.firebase:firebase-messaging:20.0.1',
             firebaseAnalytics   : 'com.google.firebase:firebase-analytics:17.2.1',
             firebasePerformance : 'com.google.firebase:firebase-perf:19.0.4',
-            crashlytics         : 'com.crashlytics.sdk.android:crashlytics:2.10.1',
             okHttp              : "com.squareup.okhttp3:okhttp:$okHttpVersion",
             deviceNames         : "com.jaredrummler:android-device-names:1.1.9"
     ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'


### PR DESCRIPTION
## Summary
- replace the Fabric Crashlytics tooling with the Firebase Crashlytics Gradle plugin and dependency
- update the app module to apply the Firebase Crashlytics plugin, use the KTX dependency via the Firebase BOM, and report exceptions through FirebaseCrashlytics
- configure plugin management repositories so Gradle can resolve plugins without the Fabric repository

## Testing
- `./gradlew build` *(fails: io.gitlab.arturbosch.detekt:1.1.1 cannot be resolved in the offline environment)*
- `./gradlew app:uploadCrashlyticsSymbolFileDebug` *(fails: io.gitlab.arturbosch.detekt:1.1.1 cannot be resolved in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70444bb0c8323af2647d32a3aef6c