### PR TITLE
Migrate UI code to ViewBinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.getkeepsafe.dexcount'
@@ -69,6 +68,10 @@ android {
         releasePreprod { java.srcDirs += 'src/debugTools/kotlin' }
     }
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     buildTypes.each { type ->
         type.buildConfigField 'String', 'FIREBASE_CLOUD_MESSAGING_SERVER_KEY', "\"$secrets.firebaseCloudMessagingServerKey\""
     }
@@ -127,11 +130,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 kapt {
     correctErrorTypes = true
 }
-
-androidExtensions {
-    experimental = true
-}
-
 configurations {
     dependencyUpdates.resolutionStrategy = {
         componentSelection { rules ->

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/common/view/BaseViewHolder.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/common/view/BaseViewHolder.kt
@@ -2,11 +2,8 @@ package co.netguru.baby.monitor.client.common.view
 
 import androidx.recyclerview.widget.RecyclerView
 import android.view.View
-import kotlinx.android.extensions.LayoutContainer
 
-abstract class BaseViewHolder<in T>(itemView: View) : RecyclerView.ViewHolder(itemView), LayoutContainer {
-
-    override val containerView: View? = itemView
+abstract class BaseViewHolder<in T>(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
     abstract fun bindView(item: T)
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/common/view/SeekBarProgress.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/common/view/SeekBarProgress.kt
@@ -3,13 +3,13 @@ package co.netguru.baby.monitor.client.common.view
 import android.content.Context
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.widget.RelativeLayout
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.feature.settings.ChangeState
-import kotlinx.android.synthetic.main.seek_bar_progress.view.*
+import co.netguru.baby.monitor.client.databinding.SeekBarProgressBinding
 
 class SeekBarProgress : RelativeLayout {
     constructor(context: Context) : super(context)
@@ -20,9 +20,7 @@ class SeekBarProgress : RelativeLayout {
         attributeSetId
     )
 
-    init {
-        View.inflate(context, R.layout.seek_bar_progress, this)
-    }
+    private val binding = SeekBarProgressBinding.inflate(LayoutInflater.from(context), this)
 
     fun setState(valueState: Pair<ChangeState?, Int?>) {
         val (changeState, value) = valueState
@@ -33,16 +31,16 @@ class SeekBarProgress : RelativeLayout {
             ChangeState.InProgress -> Unit
             null -> {
                 value?.let {
-                    progressText.text = it.toString()
+                    binding.progressText.text = it.toString()
                 }
             }
         }
     }
 
     private fun resolveVisibility(changeState: ChangeState?) {
-        progressText.isVisible = changeState == null
-        progress.isVisible = changeState == ChangeState.InProgress
-        progressIcon.isVisible =
+        binding.progressText.isVisible = changeState == null
+        binding.progress.isVisible = changeState == ChangeState.InProgress
+        binding.progressIcon.isVisible =
             changeState == ChangeState.Completed || changeState == ChangeState.Failed
     }
 
@@ -52,7 +50,7 @@ class SeekBarProgress : RelativeLayout {
             if (success) R.drawable.animated_done else R.drawable.animated_fail
         ) as? AnimatedVectorDrawable
         animatedVectorDrawable?.let {
-            progressIcon.setImageDrawable(it)
+            binding.progressIcon.setImageDrawable(it)
             it.start()
         }
     }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/AllDoneFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/AllDoneFragment.kt
@@ -5,21 +5,29 @@ import android.view.View
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentAllDoneBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_all_done.*
 
 class AllDoneFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_all_done
     override val screen: Screen = Screen.ALL_DONE
+    private var _binding: FragmentAllDoneBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        addDoneCtrl.setOnClickListener {
+        _binding = FragmentAllDoneBinding.bind(view)
+        binding.addDoneCtrl.setOnClickListener {
             findNavController().navigate(R.id.allDoneToClientHome)
             requireActivity().finish()
         }
-        allDoneBackIv.setOnClickListener {
+        binding.allDoneBackIv.setOnClickListener {
             findNavController().navigateUp()
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/ParentDeviceInfoFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/configuration/ParentDeviceInfoFragment.kt
@@ -5,21 +5,29 @@ import android.view.View
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentParentDeviceInfoBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_parent_device_info.*
 
 class ParentDeviceInfoFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_parent_device_info
     override val screen: Screen = Screen.PARENT_DEVICE_INFO
+    private var _binding: FragmentParentDeviceInfoBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        secondAppButtonCtrl.setOnClickListener {
+        _binding = FragmentParentDeviceInfoBinding.bind(view)
+        binding.secondAppButtonCtrl.setOnClickListener {
             findNavController().navigate(R.id.secondAppInfoToServiceDiscovery)
         }
 
-        secondAppInfoBackIv.setOnClickListener {
+        binding.secondAppInfoBackIv.setOnClickListener {
             findNavController().navigateUp()
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/ClientHomeActivity.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/ClientHomeActivity.kt
@@ -15,6 +15,7 @@ import co.netguru.baby.monitor.client.common.extensions.observeNonNull
 import co.netguru.baby.monitor.client.common.extensions.setVisible
 import co.netguru.baby.monitor.client.data.client.ChildDataEntity
 import co.netguru.baby.monitor.client.data.client.home.ToolbarState
+import co.netguru.baby.monitor.client.databinding.ActivityClientHomeBinding
 import co.netguru.baby.monitor.client.feature.babynotification.SnoozeNotificationUseCase.Companion.SNOOZE_DIALOG_TAG
 import co.netguru.baby.monitor.client.feature.communication.websocket.Message
 import co.netguru.baby.monitor.client.feature.onboarding.OnboardingActivity
@@ -23,9 +24,6 @@ import co.netguru.baby.monitor.client.feature.settings.ChangeState
 import com.bumptech.glide.request.RequestOptions
 import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.DaggerAppCompatActivity
-import kotlinx.android.synthetic.main.activity_client_home.*
-import kotlinx.android.synthetic.main.toolbar_child.*
-import kotlinx.android.synthetic.main.toolbar_default.*
 import timber.log.Timber
 import java.net.URI
 import javax.inject.Inject
@@ -42,10 +40,12 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
     private val configurationViewModel by lazy {
         ViewModelProviders.of(this, factory)[ConfigurationViewModel::class.java]
     }
+    private lateinit var binding: ActivityClientHomeBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_client_home)
+        binding = ActivityClientHomeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         controlVideoStreamVolume()
 
         setupView()
@@ -78,7 +78,7 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
         homeViewModel.backButtonState.observe(
             this,
             Observer {
-                backIbtn.setVisible(it?.shouldBeVisible == true)
+                binding.childToolbarLayout.backIbtn.setVisible(it?.shouldBeVisible == true)
                 setBackButtonClick(it?.shouldShowSnoozeDialog == true)
             })
 
@@ -115,13 +115,13 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
         findNavController(R.id.clientDashboardNavigationHostFragment).navigateUp()
 
     private fun setupView() {
-        toolbarSettingsIbtn.setOnClickListener {
+        binding.childToolbarLayout.toolbarSettingsIbtn.setOnClickListener {
             homeViewModel.shouldDrawerBeOpen.postValue(true)
         }
-        toolbarBackBtn.setOnClickListener {
+        binding.defaultToolbarLayout.toolbarBackBtn.setOnClickListener {
             findNavController(R.id.clientDashboardNavigationHostFragment).navigateUp()
         }
-        client_drawer.isDrawerOpen(GravityCompat.END)
+        binding.clientDrawer.isDrawerOpen(GravityCompat.END)
     }
 
     private fun handleSelectedChild(child: ChildDataEntity) {
@@ -130,19 +130,19 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
             .load(child.image)
             .placeholder(R.drawable.baby_logo)
             .apply(RequestOptions.circleCropTransform())
-            .into(toolbarChildMiniatureIv)
+            .into(binding.childToolbarLayout.toolbarChildMiniatureIv)
     }
 
     private fun handleDrawerEvent(shouldClose: Boolean?) {
         if (shouldClose == true) {
-            client_drawer.openDrawer(GravityCompat.END)
+            binding.clientDrawer.openDrawer(GravityCompat.END)
         } else {
-            client_drawer.closeDrawer(GravityCompat.END)
+            binding.clientDrawer.closeDrawer(GravityCompat.END)
         }
     }
 
     private fun showErrorSnackbar(messageResource: Int) {
-        Snackbar.make(coordinator, messageResource, Snackbar.LENGTH_INDEFINITE)
+        Snackbar.make(binding.coordinator, messageResource, Snackbar.LENGTH_INDEFINITE)
             .setAction(getString(R.string.restart)) {
                 homeViewModel.restartApp(this)
             }
@@ -150,7 +150,7 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
     }
 
     private fun setBackButtonClick(shouldShowSnoozeDialog: Boolean) {
-        backIbtn.setOnClickListener {
+        binding.childToolbarLayout.backIbtn.setOnClickListener {
             findNavController(R.id.clientDashboardNavigationHostFragment).navigateUp()
             if (shouldShowSnoozeDialog) showSnoozeDialog()
         }
@@ -171,7 +171,7 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
     }
 
     private fun setSelectedChildName(name: String) {
-        toolbarChildTv.text = if (name.isNotEmpty()) {
+        binding.childToolbarLayout.toolbarChildTv.text = if (name.isNotEmpty()) {
             name
         } else {
             getString(R.string.no_name)
@@ -181,17 +181,17 @@ class ClientHomeActivity : DaggerAppCompatActivity(),
     private fun handleToolbarStateChange(state: ToolbarState?) {
         when (state) {
             ToolbarState.HIDDEN -> {
-                childToolbarLayout.setVisible(false)
-                defaultToolbarLayout.setVisible(false)
+                binding.childToolbarLayout.root.setVisible(false)
+                binding.defaultToolbarLayout.root.setVisible(false)
             }
             ToolbarState.HISTORY -> {
-                childToolbarLayout.setVisible(false)
-                defaultToolbarLayout.setVisible(true)
-                toolbarTitleTv.text = getString(R.string.latest_activity)
+                binding.childToolbarLayout.root.setVisible(false)
+                binding.defaultToolbarLayout.root.setVisible(true)
+                binding.defaultToolbarLayout.toolbarTitleTv.text = getString(R.string.latest_activity)
             }
             ToolbarState.DEFAULT -> {
-                defaultToolbarLayout.setVisible(false)
-                childToolbarLayout.setVisible(true)
+                binding.defaultToolbarLayout.root.setVisible(false)
+                binding.childToolbarLayout.root.setVisible(true)
             }
         }
     }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/dashboard/ClientDashboardFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/dashboard/ClientDashboardFragment.kt
@@ -14,12 +14,12 @@ import co.netguru.baby.monitor.client.common.PermissionUtils
 import co.netguru.baby.monitor.client.common.base.BaseFragment
 import co.netguru.baby.monitor.client.common.extensions.getColor
 import co.netguru.baby.monitor.client.common.extensions.observeNonNull
+import co.netguru.baby.monitor.client.databinding.FragmentClientDashboardBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
 import co.netguru.baby.monitor.client.feature.client.home.ClientHomeViewModel
 import com.bumptech.glide.request.RequestOptions
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_client_dashboard.*
 import javax.inject.Inject
 
 class ClientDashboardFragment : BaseFragment() {
@@ -31,6 +31,8 @@ class ClientDashboardFragment : BaseFragment() {
     private val viewModel by lazy {
         ViewModelProviders.of(requireActivity(), factory)[ClientHomeViewModel::class.java]
     }
+    private var _binding: FragmentClientDashboardBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,15 +41,16 @@ class ClientDashboardFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentClientDashboardBinding.bind(view)
         setupObservers()
-        clientHomeActivityLogIbtn.setOnClickListener {
+        binding.clientHomeActivityLogIbtn.setOnClickListener {
             findNavController().navigate(R.id.actionDashboardToLogs)
         }
     }
 
     private fun setupObservers() {
         viewModel.selectedChildLiveData.observeNonNull(viewLifecycleOwner) { child ->
-            clientHomeBabyNameTv.apply {
+            binding.clientHomeBabyNameTv.apply {
                 if (child.name.isNullOrBlank()) {
                     text = getString(R.string.your_baby_name)
                     setTextColor(getColor(R.color.accent))
@@ -61,8 +64,8 @@ class ClientDashboardFragment : BaseFragment() {
                 GlideApp.with(requireContext())
                     .load(child.image)
                     .apply(RequestOptions.circleCropTransform())
-                    .into(clientHomeBabyIv)
-                clientHomeBabyIv.setPadding(NO_PADDING)
+                    .into(binding.clientHomeBabyIv)
+                binding.clientHomeBabyIv.setPadding(NO_PADDING)
             }
         }
         viewModel.selectedChildAvailability.observeNonNull(viewLifecycleOwner) { childAvailable ->
@@ -75,17 +78,17 @@ class ClientDashboardFragment : BaseFragment() {
     }
 
     private fun showClientConnected() {
-        clientConnectionStatusTv.text = getString(R.string.devices_connected)
-        clientConnectionStatusPv.start()
-        clientHomeLiveCameraIbtn.setOnClickListener {
+        binding.clientConnectionStatusTv.text = getString(R.string.devices_connected)
+        binding.clientConnectionStatusPv.start()
+        binding.clientHomeLiveCameraIbtn.setOnClickListener {
             requestMicrophonePermission()
         }
     }
 
     private fun showClientDisconnected() {
-        clientConnectionStatusTv.text = getString(R.string.devices_disconnected)
-        clientConnectionStatusPv.stop()
-        clientHomeLiveCameraIbtn.setOnClickListener {
+        binding.clientConnectionStatusTv.text = getString(R.string.devices_disconnected)
+        binding.clientConnectionStatusPv.stop()
+        binding.clientHomeLiveCameraIbtn.setOnClickListener {
             Toast.makeText(
                 requireContext(),
                 getString(R.string.child_not_available),
@@ -103,13 +106,20 @@ class ClientDashboardFragment : BaseFragment() {
 
     private fun showRationaleSnackbar() {
         Snackbar.make(
-            requireView(),
+            binding.root,
             getString(R.string.parent_microphone_permission),
             Snackbar.LENGTH_SHORT
         )
             .setAction(getString(R.string.check_again)) { requestMicrophonePermission() }
             .setDuration(BaseTransientBottomBar.LENGTH_LONG)
             .show()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.clientConnectionStatusPv.stop()
+        binding.clientHomeLiveCameraIbtn.setOnClickListener(null)
+        _binding = null
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/livecamera/ClientLiveCameraFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/livecamera/ClientLiveCameraFragment.kt
@@ -12,6 +12,7 @@ import co.netguru.baby.monitor.client.common.PermissionUtils
 import co.netguru.baby.monitor.client.common.base.BaseFragment
 import co.netguru.baby.monitor.client.common.extensions.scaleAnimation
 import co.netguru.baby.monitor.client.common.extensions.showSnackbarMessage
+import co.netguru.baby.monitor.client.databinding.FragmentClientLiveCameraBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
 import co.netguru.baby.monitor.client.feature.babynotification.BabyEventActionIntentService
 import co.netguru.baby.monitor.client.feature.client.home.BackButtonState
@@ -20,7 +21,6 @@ import co.netguru.baby.monitor.client.feature.communication.webrtc.ConnectionSta
 import co.netguru.baby.monitor.client.feature.communication.webrtc.RtcConnectionState
 import co.netguru.baby.monitor.client.feature.communication.webrtc.StreamState
 import co.netguru.baby.monitor.client.feature.communication.websocket.RxWebSocketClient
-import kotlinx.android.synthetic.main.fragment_client_live_camera.*
 import timber.log.Timber
 import java.net.URI
 import javax.inject.Inject
@@ -39,9 +39,12 @@ class ClientLiveCameraFragment : BaseFragment() {
     private val fragmentViewModel by lazy {
         ViewModelProviders.of(this, factory)[ClientLiveCameraFragmentViewModel::class.java]
     }
+    private var _binding: FragmentClientLiveCameraBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentClientLiveCameraBinding.bind(view)
         viewModel.setBackButtonState(
             BackButtonState(
                 true,
@@ -60,13 +63,13 @@ class ClientLiveCameraFragment : BaseFragment() {
         ) {
             enablePushToSpeakButton()
         } else {
-            pushToSpeakButton.isVisible = false
+            binding.pushToSpeakButton.isVisible = false
         }
     }
 
     private fun enablePushToSpeakButton() {
-        pushToSpeakButton.isVisible = true
-        pushToSpeakButton.setOnTouchListener { _, event ->
+        binding.pushToSpeakButton.isVisible = true
+        binding.pushToSpeakButton.setOnTouchListener { _, event ->
             if (event.action == MotionEvent.ACTION_DOWN) {
                 onPushToSpeakButtonPressed()
             } else if (event.action == MotionEvent.ACTION_UP) {
@@ -78,7 +81,7 @@ class ClientLiveCameraFragment : BaseFragment() {
 
     private fun onPushToSpeakButtonRelease() {
         fragmentViewModel.pushToSpeak(false)
-        pushToSpeakButton.scaleAnimation(
+        binding.pushToSpeakButton.scaleAnimation(
             false,
             PRESSED_SCALE,
             NORMAL_SCALE,
@@ -88,7 +91,7 @@ class ClientLiveCameraFragment : BaseFragment() {
 
     private fun onPushToSpeakButtonPressed() {
         fragmentViewModel.pushToSpeak(true)
-        pushToSpeakButton.scaleAnimation(
+        binding.pushToSpeakButton.scaleAnimation(
             true,
             PRESSED_SCALE,
             NORMAL_SCALE,
@@ -151,7 +154,7 @@ class ClientLiveCameraFragment : BaseFragment() {
         val serverUri = URI.create(viewModel.selectedChildLiveData.value?.address ?: return)
         fragmentViewModel.startCall(
             requireActivity().applicationContext,
-            liveCameraRemoteRenderer,
+            binding.liveCameraRemoteRenderer,
             serverUri,
             rxWebSocketClient,
             hasRecordAudioPermission
@@ -161,8 +164,8 @@ class ClientLiveCameraFragment : BaseFragment() {
     private fun handleStreamStateChange(streamState: StreamState) {
         when ((streamState as? ConnectionState)?.connectionState) {
             RtcConnectionState.Connected,
-            RtcConnectionState.Completed -> streamProgressBar.isVisible = false
-            RtcConnectionState.Checking -> streamProgressBar.isVisible = true
+            RtcConnectionState.Completed -> binding.streamProgressBar.isVisible = false
+            RtcConnectionState.Checking -> binding.streamProgressBar.isVisible = true
             RtcConnectionState.Error -> handleBabyDeviceSdpError()
             else -> Unit
         }
@@ -171,6 +174,12 @@ class ClientLiveCameraFragment : BaseFragment() {
     private fun handleBabyDeviceSdpError() {
         showSnackbarMessage(R.string.stream_error)
         requireActivity().onBackPressed()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.pushToSpeakButton.setOnTouchListener(null)
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/log/ClientActivityLogFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/log/ClientActivityLogFragment.kt
@@ -10,9 +10,9 @@ import co.netguru.baby.monitor.client.common.extensions.observeNonNull
 import co.netguru.baby.monitor.client.common.extensions.setVisible
 import co.netguru.baby.monitor.client.common.view.StickyHeaderDecorator
 import co.netguru.baby.monitor.client.data.client.home.ToolbarState
+import co.netguru.baby.monitor.client.databinding.FragmentClientActivityLogBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
 import co.netguru.baby.monitor.client.feature.client.home.ClientHomeViewModel
-import kotlinx.android.synthetic.main.fragment_client_activity_log.*
 import javax.inject.Inject
 
 class ClientActivityLogFragment : BaseFragment() {
@@ -26,6 +26,8 @@ class ClientActivityLogFragment : BaseFragment() {
     private val viewModel by lazy {
         ViewModelProviders.of(requireActivity(), factory)[ClientHomeViewModel::class.java]
     }
+    private var _binding: FragmentClientActivityLogBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,24 +36,27 @@ class ClientActivityLogFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentClientActivityLogBinding.bind(view)
         setupRecyclerView()
 
-        viewModel.logData.observeNonNull(this, { activities ->
+        viewModel.logData.observeNonNull(viewLifecycleOwner, { activities ->
             if (activities.isNotEmpty()) {
                 logAdapter.setupList(activities)
             }
-            clientActivityLogRv.setVisible(activities.isNotEmpty())
-            clientActivityLogEndTv.setVisible(activities.isEmpty())
+            binding.clientActivityLogRv.setVisible(activities.isNotEmpty())
+            binding.clientActivityLogEndTv.setVisible(activities.isEmpty())
         })
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         viewModel.toolbarState.postValue(ToolbarState.DEFAULT)
+        binding.clientActivityLogRv.adapter = null
+        _binding = null
     }
 
     private fun setupRecyclerView() {
-        with(clientActivityLogRv) {
+        with(binding.clientActivityLogRv) {
             adapter = logAdapter
             addItemDecoration(StickyHeaderDecorator(logAdapter))
         }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/log/LogsViewHolder.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/client/home/log/LogsViewHolder.kt
@@ -6,8 +6,8 @@ import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.DateProvider
 import co.netguru.baby.monitor.client.common.view.BaseViewHolder
 import co.netguru.baby.monitor.client.data.client.home.log.LogData
-import kotlinx.android.synthetic.main.item_log_activity_header.*
-import kotlinx.android.synthetic.main.item_log_activity_record.*
+import co.netguru.baby.monitor.client.databinding.ItemLogActivityHeaderBinding
+import co.netguru.baby.monitor.client.databinding.ItemLogActivityRecordBinding
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.temporal.ChronoUnit
 
@@ -23,13 +23,15 @@ abstract class LogsViewHolder(
         viewType: Int
     ) : LogsViewHolder(parent, viewType) {
 
+        private val binding = ItemLogActivityRecordBinding.bind(itemView)
+
         override fun bindView(item: LogData) {
             val hourBefore = LocalDateTime.now().minusHours(1)
             if (item is LogData.Data) {
-                itemActivityLogActionTv.text = item.action
+                binding.itemActivityLogActionTv.text = item.action
                 val minutesAgo =
                     (HOUR_IN_MINUTES - hourBefore.until(item.timeStamp, ChronoUnit.MINUTES)).toInt()
-                itemActivityLogActionTimestampTv.text = if (item.timeStamp.isAfter(hourBefore)) {
+                binding.itemActivityLogActionTimestampTv.text = if (item.timeStamp.isAfter(hourBefore)) {
                     itemView.context.resources.getQuantityString(
                         R.plurals.minutes_ago, minutesAgo, minutesAgo
                     )
@@ -45,12 +47,14 @@ abstract class LogsViewHolder(
         viewType: Int
     ) : LogsViewHolder(parent, viewType) {
 
+        private val binding = ItemLogActivityHeaderBinding.bind(itemView)
+
         override fun bindView(item: LogData) {
             val today = DateProvider.midnight
             val yesterday = DateProvider.yesterdaysMidnight
             val baseText = item.timeStamp.format(DateProvider.headerFormatter)
 
-            itemActivityLogHeaderTv.text = when {
+            binding.itemActivityLogHeaderTv.text = when {
                 item.timeStamp.isAfter(today) -> itemView.context.getString(
                     R.string.date_today,
                     baseText

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/nsd/ServiceViewHolder.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/nsd/ServiceViewHolder.kt
@@ -4,13 +4,15 @@ import android.net.nsd.NsdServiceInfo
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import co.netguru.baby.monitor.client.R
-import kotlinx.android.synthetic.main.found_service_item.view.*
+import co.netguru.baby.monitor.client.databinding.FoundServiceItemBinding
 
 class ServiceViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
+    private val binding = FoundServiceItemBinding.bind(view)
+
     fun bind(nsdServiceInfo: NsdServiceInfo) {
         val deviceName = nsdServiceInfo.serviceName.removeSuffix(NsdServiceManager.SERVICE_NAME)
-        itemView.deviceName.text =
+        binding.deviceName.text =
             if (deviceName.isNotEmpty()) deviceName else itemView.resources.getString(
                 R.string.unknown_device
             )

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/ConnectingDevicesFailedFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/ConnectingDevicesFailedFragment.kt
@@ -6,16 +6,19 @@ import androidx.activity.OnBackPressedCallback
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentFailedDevicesConnectingBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_failed_devices_connecting.*
 
 class ConnectingDevicesFailedFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_failed_devices_connecting
     override val screen: Screen = Screen.CONNECTION_FAILED
+    private var _binding: FragmentFailedDevicesConnectingBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        configurationFailedTryAgainButton.setOnClickListener {
+        _binding = FragmentFailedDevicesConnectingBinding.bind(view)
+        binding.configurationFailedTryAgainButton.setOnClickListener {
             findNavController().navigate(R.id.connectionFailedToServiceDiscovery)
         }
         setupOnBackPressedHandling()
@@ -28,5 +31,10 @@ class ConnectingDevicesFailedFragment : BaseFragment() {
                 findNavController().navigate(R.id.connectionFailedToServiceDiscovery)
             }
         })
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/PairingFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/PairingFragment.kt
@@ -9,8 +9,8 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentPairingBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_pairing.*
 import java.net.URI
 import javax.inject.Inject
 
@@ -24,9 +24,12 @@ class PairingFragment : BaseFragment() {
     private val viewModel by lazy {
         ViewModelProviders.of(this, factory)[PairingViewModel::class.java]
     }
+    private var _binding: FragmentPairingBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentPairingBinding.bind(view)
         setupObservers()
         setupViews()
         handlePairingCodeArgument()
@@ -39,7 +42,7 @@ class PairingFragment : BaseFragment() {
     }
 
     private fun setupViews() {
-        pairingCode.text = viewModel.randomPairingCode
+        binding.pairingCode.text = viewModel.randomPairingCode
         setupOnBackPressedHandling()
     }
 
@@ -51,7 +54,7 @@ class PairingFragment : BaseFragment() {
                 findNavController().popBackStack()
             }
         })
-        backButton.setOnClickListener {
+        binding.backButton.setOnClickListener {
             requireActivity().onBackPressed()
         }
     }
@@ -69,5 +72,10 @@ class PairingFragment : BaseFragment() {
                 R.id.pairingToConnectionFailed
             }
         )
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/ServiceDiscoveryFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/communication/pairing/ServiceDiscoveryFragment.kt
@@ -17,6 +17,7 @@ import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
 import co.netguru.baby.monitor.client.common.extensions.setDivider
 import co.netguru.baby.monitor.client.common.extensions.showSnackbarMessage
+import co.netguru.baby.monitor.client.databinding.FragmentConnectingDevicesBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
 import co.netguru.baby.monitor.client.feature.communication.nsd.NsdServicesAdapter
 import co.netguru.baby.monitor.client.feature.communication.nsd.NsdState
@@ -24,7 +25,6 @@ import co.netguru.baby.monitor.client.feature.communication.nsd.ResolveFailedExc
 import co.netguru.baby.monitor.client.feature.communication.nsd.StartDiscoveryFailedException
 import io.reactivex.Single
 import io.reactivex.disposables.Disposable
-import kotlinx.android.synthetic.main.fragment_connecting_devices.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -40,9 +40,12 @@ class ServiceDiscoveryFragment : BaseFragment() {
     private val viewModel by lazy {
         ViewModelProviders.of(this, factory)[ServiceDiscoveryViewModel::class.java]
     }
+    private var _binding: FragmentConnectingDevicesBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentConnectingDevicesBinding.bind(view)
         setupAdapter()
         setupObservers()
         setupInProgressViews()
@@ -51,7 +54,7 @@ class ServiceDiscoveryFragment : BaseFragment() {
     private fun setupAdapter() {
         nsdServicesAdapter =
             NsdServicesAdapter { nsdServiceInfo -> navigateToPairingFragment(nsdServiceInfo) }
-        recyclerView.apply {
+        binding.recyclerView.apply {
             layoutManager =
                 LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
             adapter = nsdServicesAdapter
@@ -77,7 +80,7 @@ class ServiceDiscoveryFragment : BaseFragment() {
         when (nsdState) {
             is NsdState.Error -> handleNsdServiceError(nsdState.throwable)
             is NsdState.InProgress -> {
-                if (motionContainer.currentState != R.id.end) motionContainer.transitionToEnd()
+                if (binding.motionContainer.currentState != R.id.end) binding.motionContainer.transitionToEnd()
                 handleServices(nsdState.serviceInfoList)
             }
             is NsdState.Completed -> {
@@ -103,30 +106,30 @@ class ServiceDiscoveryFragment : BaseFragment() {
     }
 
     private fun setupCompleteViews() {
-        cancelRefreshButton.apply {
+        binding.cancelRefreshButton.apply {
             setOnClickListener {
                 discoverNsdService()
             }
             text = resources.getString(R.string.refresh_list)
         }
-        backButton.apply {
+        binding.backButton.apply {
             isVisible = true
             setOnClickListener {
                 findNavController().navigateUp()
             }
         }
-        progressBar.isVisible = false
+        binding.progressBar.isVisible = false
     }
 
     private fun setupInProgressViews() {
-        cancelRefreshButton.apply {
+        binding.cancelRefreshButton.apply {
             setOnClickListener {
                 goBackToSpecifyDevice()
             }
             text = resources.getString(R.string.cancel)
         }
-        backButton.isVisible = false
-        progressBar.isVisible = true
+        binding.backButton.isVisible = false
+        binding.progressBar.isVisible = true
     }
 
     private fun handleServices(serviceInfoList: List<NsdServiceInfo>) {
@@ -169,6 +172,8 @@ class ServiceDiscoveryFragment : BaseFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         nsdServicesAdapter = null
+        binding.recyclerView.adapter = null
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/debug/DebugView.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/debug/DebugView.kt
@@ -3,13 +3,13 @@ package co.netguru.baby.monitor.client.feature.debug
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.widget.LinearLayout
 import co.netguru.baby.monitor.client.R
+import co.netguru.baby.monitor.client.databinding.DebugViewBinding
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
-import kotlinx.android.synthetic.main.debug_view.view.*
 
 class DebugView : LinearLayout {
     constructor(context: Context) : super(context)
@@ -22,10 +22,10 @@ class DebugView : LinearLayout {
 
     private var disposable: Disposable? = null
 
+    private val binding = DebugViewBinding.inflate(LayoutInflater.from(context), this, true)
+
     init {
-        View.inflate(context, R.layout.debug_view, this).apply {
-            orientation = VERTICAL
-        }
+        orientation = VERTICAL
     }
 
     fun setDebugStateObservable(observable: Observable<DebugState>) {
@@ -42,10 +42,10 @@ class DebugView : LinearLayout {
 
     @SuppressLint("SetTextI18n")
     private fun setDebugState(debugState: DebugState) {
-        cryingProbability.text = "$CRYING_PROBABILITY_PREFIX ${debugState.cryingProbability}"
-        notificationInformation.text =
+        binding.cryingProbability.text = "$CRYING_PROBABILITY_PREFIX ${debugState.cryingProbability}"
+        binding.notificationInformation.text =
             "$NOTIFICATION_INFORMATION_PREFIX ${debugState.notificationInformation}"
-        soundDecibels.text = "$SOUND_DECIBELS_PREFIX ${debugState.decibels}"
+        binding.soundDecibels.text = "$SOUND_DECIBELS_PREFIX ${debugState.decibels}"
     }
 
     companion object {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/FeaturePresentationFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/FeaturePresentationFragment.kt
@@ -6,12 +6,15 @@ import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.navigation.fragment.findNavController
+import androidx.viewbinding.ViewBinding
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentFeatureABinding
+import co.netguru.baby.monitor.client.databinding.FragmentFeatureBBinding
+import co.netguru.baby.monitor.client.databinding.FragmentFeatureCBinding
+import co.netguru.baby.monitor.client.databinding.OnboardingButtonsBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.onboarding_buttons.*
 import javax.inject.Inject
 
 class FeaturePresentationFragment : BaseFragment() {
@@ -21,34 +24,55 @@ class FeaturePresentationFragment : BaseFragment() {
     @Inject
     lateinit var finishOnboardingUseCase: FinishOnboardingUseCase
 
+    private var _binding: ViewBinding? = null
+    private val onboardingButtonsBinding: OnboardingButtonsBinding
+        get() = when (val binding = _binding) {
+            is FragmentFeatureABinding -> binding.onboardingButtons
+            is FragmentFeatureBBinding -> binding.onboardingButtons
+            is FragmentFeatureCBinding -> binding.onboardingButtons
+            else -> throw IllegalStateException("Binding not initialized")
+        }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        layoutResource = when (arguments?.getString(FEATURE_KEY)) {
-            FEATURE_B -> R.layout.fragment_feature_b
-            FEATURE_C -> R.layout.fragment_feature_c
-            else -> R.layout.fragment_feature_a
+        val featureLayout = when (arguments?.getString(FEATURE_KEY)) {
+            FEATURE_B -> FragmentFeatureBBinding.inflate(inflater, container, false).also {
+                layoutResource = R.layout.fragment_feature_b
+            }
+            FEATURE_C -> FragmentFeatureCBinding.inflate(inflater, container, false).also {
+                layoutResource = R.layout.fragment_feature_c
+            }
+            else -> FragmentFeatureABinding.inflate(inflater, container, false).also {
+                layoutResource = R.layout.fragment_feature_a
+            }
         }
-        return inflater.inflate(layoutResource, container, false)
+        _binding = featureLayout
+        return featureLayout.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<TextView>(R.id.tos)?.apply {
+        (_binding as? FragmentFeatureCBinding)?.tos?.apply {
             text = HtmlCompat.fromHtml(
                 getString(R.string.tos_confirmation),
                 HtmlCompat.FROM_HTML_MODE_COMPACT
             )
             movementMethod = LinkMovementMethod.getInstance()
         }
-        featureNextBtn.setOnClickListener {
+        onboardingButtonsBinding.featureNextBtn.setOnClickListener {
             handleNextClicked()
         }
-        featureSkipBtn.setOnClickListener {
+        onboardingButtonsBinding.featureSkipBtn.setOnClickListener {
             findNavController().navigate(finishOnboarding())
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun handleNextClicked() {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/InfoAboutDevicesFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/InfoAboutDevicesFragment.kt
@@ -6,18 +6,26 @@ import android.view.View
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentInfoAboutDevicesBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_info_about_devices.*
 
 class InfoAboutDevicesFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_info_about_devices
     override val screen: Screen = Screen.INFO_ABOUT_DEVICES
+    private var _binding: FragmentInfoAboutDevicesBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        specifyDeviceDescriptionTv.text = Html.fromHtml(getString(R.string.sync_description))
-        specifyDeviceBtn.setOnClickListener {
+        _binding = FragmentInfoAboutDevicesBinding.bind(view)
+        binding.specifyDeviceDescriptionTv.text = Html.fromHtml(getString(R.string.sync_description))
+        binding.specifyDeviceBtn.setOnClickListener {
             findNavController().navigate(R.id.infoAboutDevicesToSpecifyDevice)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/SpecifyDeviceFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/SpecifyDeviceFragment.kt
@@ -5,20 +5,28 @@ import android.view.View
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentSpecifyDeviceBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_specify_device.*
 
 class SpecifyDeviceFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_specify_device
     override val screen: Screen = Screen.SPECIFY_DEVICE
+    private var _binding: FragmentSpecifyDeviceBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        babyCtl.setOnClickListener {
+        _binding = FragmentSpecifyDeviceBinding.bind(view)
+        binding.babyCtl.setOnClickListener {
             findNavController().navigate(R.id.specifyDeviceToFeatureD)
         }
-        parentCtl.setOnClickListener {
+        binding.parentCtl.setOnClickListener {
             findNavController().navigate(R.id.specifyDeviceToParentDeviceInfo)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/VoiceRecordingsSettingsFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/VoiceRecordingsSettingsFragment.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentVoiceRecordingsSettingBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
 import co.netguru.baby.monitor.client.feature.settings.ConfigurationViewModel
-import kotlinx.android.synthetic.main.fragment_voice_recordings_setting.*
 import javax.inject.Inject
 
 class VoiceRecordingsSettingsFragment : BaseFragment() {
@@ -20,14 +20,22 @@ class VoiceRecordingsSettingsFragment : BaseFragment() {
     lateinit var factory: ViewModelProvider.Factory
 
     private val viewModel by lazy { ViewModelProviders.of(this, factory)[ConfigurationViewModel::class.java] }
+    private var _binding: FragmentVoiceRecordingsSettingBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        featureDNextBtn.setOnClickListener {
+        _binding = FragmentVoiceRecordingsSettingBinding.bind(view)
+        binding.featureDNextBtn.setOnClickListener {
             findNavController().navigate(R.id.featureDToConnecting)
         }
-        featureDSwitch.setOnCheckedChangeListener { buttonView, isChecked ->
+        binding.featureDSwitch.setOnCheckedChangeListener { _, isChecked ->
             viewModel.setUploadEnabled(isChecked)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/baby/ConnectWifiFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/baby/ConnectWifiFragment.kt
@@ -10,18 +10,21 @@ import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
 import co.netguru.baby.monitor.client.common.extensions.allPermissionsGranted
+import co.netguru.baby.monitor.client.databinding.FragmentConnectWifiBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_connect_wifi.*
 
 class ConnectWifiFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_connect_wifi
     override val screen: Screen = Screen.CONNECT_WIFI
 
     private val wifiReceiver by lazy { WifiReceiver() }
+    private var _binding: FragmentConnectWifiBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        wifiConnectionButton.setOnClickListener {
+        _binding = FragmentConnectWifiBinding.bind(view)
+        binding.wifiConnectionButton.setOnClickListener {
             if (wifiReceiver.isWifiConnected.value?.fetchData() == true) {
                 findNavController().navigate(
                     when {
@@ -36,8 +39,8 @@ class ConnectWifiFragment : BaseFragment() {
                 startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
             }
         }
-        wifiReceiver.isWifiConnected.observe(this, Observer { isConnected ->
-            wifiConnectionButton.text = if (isConnected?.fetchData() == true) {
+        wifiReceiver.isWifiConnected.observe(viewLifecycleOwner, Observer { isConnected ->
+            binding.wifiConnectionButton.text = if (isConnected?.fetchData() == true) {
                 getString(R.string.connect_wifi_connected)
             } else {
                 getString(R.string.connect_to_wi_fi)
@@ -53,6 +56,11 @@ class ConnectWifiFragment : BaseFragment() {
     override fun onPause() {
         super.onPause()
         requireContext().unregisterReceiver(wifiReceiver)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/baby/PermissionDenied.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/baby/PermissionDenied.kt
@@ -5,20 +5,28 @@ import android.view.View
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentDeniedPermissionBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_denied_permission.*
 
 class PermissionDenied : BaseFragment() {
     override val layoutResource = R.layout.fragment_denied_permission
     override val screen: Screen = Screen.PERMISSION_DENIED
+    private var _binding: FragmentDeniedPermissionBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        deniedRetryButtonCtrl.setOnClickListener {
+        _binding = FragmentDeniedPermissionBinding.bind(view)
+        binding.deniedRetryButtonCtrl.setOnClickListener {
             findNavController().popBackStack(R.id.connectWiFi, false)
         }
-        deniedSureButtonCtrl.setOnClickListener {
+        binding.deniedSureButtonCtrl.setOnClickListener {
             requireActivity().finish()
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/baby/SetupInformationFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/onboarding/baby/SetupInformationFragment.kt
@@ -5,18 +5,26 @@ import android.view.View
 import androidx.navigation.fragment.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentConnectingSetupInformationBinding
 import co.netguru.baby.monitor.client.feature.analytics.Screen
-import kotlinx.android.synthetic.main.fragment_connecting_setup_information.*
 
 class SetupInformationFragment : BaseFragment() {
     override val layoutResource = R.layout.fragment_connecting_setup_information
     override val screen: Screen = Screen.SETUP_INFORMATION
+    private var _binding: FragmentConnectingSetupInformationBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        connectionInformationMbtn.setOnClickListener {
+        _binding = FragmentConnectingSetupInformationBinding.bind(view)
+        binding.connectionInformationMbtn.setOnClickListener {
             findNavController().navigate(R.id.setupInformationToServer)
             requireActivity().finish()
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/server/ServerActivity.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/server/ServerActivity.kt
@@ -14,6 +14,7 @@ import androidx.navigation.findNavController
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.YesNoDialog
 import co.netguru.baby.monitor.client.common.extensions.controlVideoStreamVolume
+import co.netguru.baby.monitor.client.databinding.ActivityServerBinding
 import co.netguru.baby.monitor.client.feature.communication.websocket.Message
 import co.netguru.baby.monitor.client.feature.communication.websocket.MessageController
 import co.netguru.baby.monitor.client.feature.communication.websocket.WebSocketServerService
@@ -22,7 +23,6 @@ import co.netguru.baby.monitor.client.feature.settings.ConfigurationViewModel
 import co.netguru.baby.monitor.client.feature.settings.ChangeState
 import dagger.android.support.DaggerAppCompatActivity
 import io.reactivex.Observable
-import kotlinx.android.synthetic.main.activity_server.*
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -38,10 +38,12 @@ class ServerActivity : DaggerAppCompatActivity(), ServiceConnection,
     private val configurationViewModel by lazy {
         ViewModelProviders.of(this, factory)[ConfigurationViewModel::class.java]
     }
+    private lateinit var binding: ActivityServerBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_server)
+        binding = ActivityServerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         controlVideoStreamVolume()
         setupObservers()
         bindService(
@@ -68,9 +70,9 @@ class ServerActivity : DaggerAppCompatActivity(), ServiceConnection,
 
         serverViewModel.shouldDrawerBeOpen.observe(this, Observer { shouldClose ->
             if (shouldClose) {
-                server_drawer.openDrawer(GravityCompat.END)
+                binding.serverDrawer.openDrawer(GravityCompat.END)
             } else {
-                server_drawer.closeDrawer(GravityCompat.END)
+                binding.serverDrawer.closeDrawer(GravityCompat.END)
             }
         })
     }

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/settings/ClientSettingsFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/settings/ClientSettingsFragment.kt
@@ -17,6 +17,7 @@ import co.netguru.baby.monitor.client.BuildConfig
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
 import co.netguru.baby.monitor.client.common.extensions.*
+import co.netguru.baby.monitor.client.databinding.FragmentClientSettingsBinding
 import co.netguru.baby.monitor.client.feature.client.home.ClientHomeViewModel
 import co.netguru.baby.monitor.client.feature.voiceAnalysis.VoiceAnalysisOption
 import io.reactivex.Observable
@@ -25,7 +26,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.fragment_client_settings.*
 import pl.aprilapps.easyphotopicker.EasyImage
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -47,61 +47,64 @@ class ClientSettingsFragment : BaseFragment() {
         ViewModelProviders.of(requireActivity(), factory)[ClientHomeViewModel::class.java]
     }
     private val viewDisposables = CompositeDisposable()
+    private var _binding: FragmentClientSettingsBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentClientSettingsBinding.bind(view)
 
         setupButtons()
         setupObservers()
         setupBabyDetails()
         setupNoiseDetectionSeekbar()
 
-        version.text =
+        binding.version.text =
             getString(R.string.version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE)
     }
 
     private fun setupBabyDetails() {
-        childPhotoIv.babyProfileImage(
+        binding.childPhotoIv.babyProfileImage(
             R.drawable.ic_select_photo_placeholder,
             BITMAP_AUTO_SIZE,
             R.color.alpha_accent,
             R.drawable.ic_select_photo_camera
         )
 
-        childNameEt.onFocusChangeListener =
+        binding.childNameEt.onFocusChangeListener =
             View.OnFocusChangeListener { view: View, hasFocus: Boolean ->
                 if (!hasFocus) {
                     settingsViewModel.hideKeyboard(view, requireContext())
-                    if (childNameEt.text.isNullOrBlank()) {
-                        childNameEt.text?.clear()
+                    if (binding.childNameEt.text.isNullOrBlank()) {
+                        binding.childNameEt.text?.clear()
                     }
-                    settingsViewModel.updateChildName(childNameEt.text.toString())
+                    settingsViewModel.updateChildName(binding.childNameEt.text.toString())
                 }
             }
     }
 
     private fun setupButtons() {
-        rateUsBtn.setOnClickListener {
+        binding.rateUsBtn.setOnClickListener {
             settingsViewModel.openMarket(requireActivity())
         }
 
-        resetAppBtn.setOnClickListener {
+        binding.resetAppBtn.setOnClickListener {
             configurationViewModel.resetApp(clientViewModel)
         }
 
-        secondPartTv.setOnClickListener {
+        binding.secondPartTv.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.company_url))))
         }
 
-        closeIbtn.setOnClickListener {
+        binding.closeIbtn.setOnClickListener {
             clientViewModel.shouldDrawerBeOpen.postValue(false)
         }
 
-        childPhotoIv.setOnClickListener {
+        binding.childPhotoIv.setOnClickListener {
             takeOrChoosePhoto()
         }
 
-        voiceAnalysisRadioButtons.setOnCheckedChangeListener(voiceAnalysisCheckChangedListener())
+        binding.voiceAnalysisRadioButtons.setOnCheckedChangeListener(voiceAnalysisCheckChangedListener())
     }
 
     private fun voiceAnalysisCheckChangedListener(): RadioGroup.OnCheckedChangeListener {
@@ -122,18 +125,18 @@ class ClientSettingsFragment : BaseFragment() {
     private fun setupObservers() {
         clientViewModel.selectedChildLiveData.observeNonNull(viewLifecycleOwner) { child ->
             if (!child.name.isNullOrEmpty()) {
-                childNameEt.setText(child.name)
+                binding.childNameEt.setText(child.name)
             }
             if (!child.image.isNullOrEmpty()) {
-                childPhotoIv.babyProfileImage(
+                binding.childPhotoIv.babyProfileImage(
                     child.image, -1f,
                     R.color.alpha_accent, R.drawable.ic_select_photo_camera
                 )
             }
             checkVoiceAnalysisOption(resolveOption(child.voiceAnalysisOption))
-            noiseDetectionGroup.isVisible =
+            binding.noiseDetectionGroup.isVisible =
                 child.voiceAnalysisOption == VoiceAnalysisOption.NOISE_DETECTION
-            noiseDetectionSeekBar.progress = child.noiseLevel
+            binding.noiseDetectionSeekBar.progress = child.noiseLevel
         }
         configurationViewModel.resetState.observe(viewLifecycleOwner, Observer { resetState ->
             when (resetState) {
@@ -155,17 +158,17 @@ class ClientSettingsFragment : BaseFragment() {
     }
 
     private fun setupNoiseLevelSeekbar(noiseLevelState: Pair<ChangeState, Int?>) {
-        noiseDetectionSeekBar.isEnabled = noiseLevelState.first != ChangeState.InProgress
+        binding.noiseDetectionSeekBar.isEnabled = noiseLevelState.first != ChangeState.InProgress
         if (noiseLevelState.first == ChangeState.Failed) setPreviousValue(
             noiseLevelState
         )
         hideNoiseChangeProgressAnimation(noiseLevelState)
-        noiseLevelProgress.setState(noiseLevelState)
+        binding.noiseLevelProgress.setState(noiseLevelState)
     }
 
     private fun setPreviousValue(noiseLevelState: Pair<ChangeState, Int?>) {
         noiseLevelState.second?.let {
-            noiseDetectionSeekBar.progress = it
+            binding.noiseDetectionSeekBar.progress = it
         }
     }
 
@@ -179,16 +182,14 @@ class ClientSettingsFragment : BaseFragment() {
                 )
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { _ ->
-                    view?.run {
-                        (this as? MotionLayout)?.transitionToStart()
-                    }
+                    (binding.root as? MotionLayout)?.transitionToStart()
                 }
         }
     }
 
     private fun setupVoiceAnalysisRadioButtons(voiceAnalysisChangeState: Pair<ChangeState, VoiceAnalysisOption?>) {
-        machineLearningOption.isEnabled = voiceAnalysisChangeState.first != ChangeState.InProgress
-        noiseDetectionOption.isEnabled = voiceAnalysisChangeState.first != ChangeState.InProgress
+        binding.machineLearningOption.isEnabled = voiceAnalysisChangeState.first != ChangeState.InProgress
+        binding.noiseDetectionOption.isEnabled = voiceAnalysisChangeState.first != ChangeState.InProgress
         voiceAnalysisChangeState.second?.run {
             checkVoiceAnalysisOption(resolveOption(this))
         }
@@ -204,19 +205,19 @@ class ClientSettingsFragment : BaseFragment() {
     }
 
     private fun checkVoiceAnalysisOption(optionToSet: Int) {
-        voiceAnalysisRadioButtons.apply {
+        binding.voiceAnalysisRadioButtons.apply {
             setOnCheckedChangeListener(null)
-            voiceAnalysisRadioButtons.check(optionToSet)
+            check(optionToSet)
             setOnCheckedChangeListener(voiceAnalysisCheckChangedListener())
         }
     }
 
     private fun setupResetButton(resetInProgress: Boolean) {
-        resetAppBtn.apply {
+        binding.resetAppBtn.apply {
             isClickable = !resetInProgress
             text = if (resetInProgress) "" else resources.getString(R.string.reset)
         }
-        resetProgressBar.isVisible = resetInProgress
+        binding.resetProgressBar.isVisible = resetInProgress
     }
 
     private fun getPictureWithEasyPicker() {
@@ -230,7 +231,7 @@ class ClientSettingsFragment : BaseFragment() {
     private fun setupNoiseDetectionSeekbar() {
         blockDrawerMovement()
         viewDisposables += Observable.create<SeekBarState> { emitter ->
-            noiseDetectionSeekBar.setOnSeekBarChangeListener(object :
+            binding.noiseDetectionSeekBar.setOnSeekBarChangeListener(object :
                 SeekBar.OnSeekBarChangeListener {
                 override fun onProgressChanged(
                     seekBar: SeekBar?,
@@ -252,7 +253,7 @@ class ClientSettingsFragment : BaseFragment() {
                     )
                 }
             })
-            emitter.setCancellable { noiseDetectionSeekBar.setOnSeekBarChangeListener(null) }
+            emitter.setCancellable { binding.noiseDetectionSeekBar.setOnSeekBarChangeListener(null) }
         }
             .distinctUntilChanged()
             .observeOn(AndroidSchedulers.mainThread())
@@ -260,7 +261,7 @@ class ClientSettingsFragment : BaseFragment() {
     }
 
     private fun blockDrawerMovement() {
-        noiseDetectionSeekBar.setOnTouchListener { v, event ->
+        binding.noiseDetectionSeekBar.setOnTouchListener { v, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> // Disallow Drawer to intercept touch events.
                     v.parent.requestDisallowInterceptTouchEvent(true)
@@ -277,7 +278,7 @@ class ClientSettingsFragment : BaseFragment() {
         when (seekBarState) {
             is SeekBarState.StartTracking -> {
                 configurationViewModel.noiseLevelInitialValue = seekBarState.initialValue
-                (requireView() as? MotionLayout)?.transitionToEnd()
+                (binding.root as? MotionLayout)?.transitionToEnd()
             }
             is SeekBarState.EndTracking -> {
                 configurationViewModel.changeNoiseLevel(
@@ -286,7 +287,7 @@ class ClientSettingsFragment : BaseFragment() {
                 )
             }
             is SeekBarState.ProgressChange
-            -> noiseLevelProgress.setState(null to seekBarState.progress)
+            -> binding.noiseLevelProgress.setState(null to seekBarState.progress)
         }
     }
 
@@ -346,6 +347,9 @@ class ClientSettingsFragment : BaseFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         viewDisposables.dispose()
+        binding.noiseDetectionSeekBar.setOnSeekBarChangeListener(null)
+        binding.noiseDetectionSeekBar.setOnTouchListener(null)
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/settings/ServerSettingsFragment.kt
+++ b/app/src/main/kotlin/co/netguru/baby/monitor/client/feature/settings/ServerSettingsFragment.kt
@@ -11,9 +11,9 @@ import androidx.lifecycle.ViewModelProviders
 import co.netguru.baby.monitor.client.BuildConfig
 import co.netguru.baby.monitor.client.R
 import co.netguru.baby.monitor.client.common.base.BaseFragment
+import co.netguru.baby.monitor.client.databinding.FragmentServerSettingsBinding
 import co.netguru.baby.monitor.client.feature.communication.websocket.MessageController
 import co.netguru.baby.monitor.client.feature.server.ServerViewModel
-import kotlinx.android.synthetic.main.fragment_server_settings.*
 import javax.inject.Inject
 
 class ServerSettingsFragment : BaseFragment() {
@@ -31,9 +31,12 @@ class ServerSettingsFragment : BaseFragment() {
     private val settingsViewModel by lazy {
         ViewModelProviders.of(this, factory)[SettingsViewModel::class.java]
     }
+    private var _binding: FragmentServerSettingsBinding? = null
+    private val binding get() = _binding!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentServerSettingsBinding.bind(view)
         setupViews()
         setupObservers()
     }
@@ -48,29 +51,29 @@ class ServerSettingsFragment : BaseFragment() {
     }
 
     private fun setupViews() {
-        sendRecordingsSw.isChecked = configurationViewModel.isUploadEnabled()
+        binding.sendRecordingsSw.isChecked = configurationViewModel.isUploadEnabled()
 
-        rateUsBtn.setOnClickListener {
+        binding.rateUsBtn.setOnClickListener {
             settingsViewModel.openMarket(requireActivity())
         }
 
-        secondPartTv.setOnClickListener {
+        binding.secondPartTv.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.company_url))))
         }
 
-        closeIbtn.setOnClickListener {
+        binding.closeIbtn.setOnClickListener {
             serverViewModel.toggleDrawer(false)
         }
 
-        resetAppBtn.setOnClickListener {
+        binding.resetAppBtn.setOnClickListener {
             resetApp()
         }
 
-        sendRecordingsSw.setOnCheckedChangeListener { _, isChecked ->
+        binding.sendRecordingsSw.setOnCheckedChangeListener { _, isChecked ->
             configurationViewModel.setUploadEnabled(isChecked)
         }
 
-        version.text =
+        binding.version.text =
             getString(R.string.version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE)
     }
 
@@ -79,10 +82,16 @@ class ServerSettingsFragment : BaseFragment() {
     }
 
     private fun setupResetButton(resetInProgress: Boolean) {
-        resetAppBtn.apply {
+        binding.resetAppBtn.apply {
             isClickable = !resetInProgress
             text = if (resetInProgress) "" else resources.getString(R.string.reset)
         }
-        resetProgressBar.isVisible = resetInProgress
+        binding.resetProgressBar.isVisible = resetInProgress
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.sendRecordingsSw.setOnCheckedChangeListener(null)
+        _binding = null
     }
 }


### PR DESCRIPTION
## Summary
- enable view binding in the app module and drop the deprecated kotlin-android-extensions plugin
- replace synthetic view access with ViewBinding throughout fragments, activities, custom views, and adapters
- clean up lifecycle handling and RecyclerView bindings to avoid leaks after the migration

## Testing
- ./gradlew build *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68d704442d308323a56df5f5f11e8fc4