### PR TITLE
Refine packaging DSL usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,12 +82,10 @@ android {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
     }
-    packagingOptions {
+    packaging {
         jniLibs {
             useLegacyPackaging true
         }
-    }
-    packaging {
         resources {
             excludes += [
                     'META-INF/services/javax.annotation.processing.Processor',


### PR DESCRIPTION
## Summary
- move the legacy JNI packaging configuration into the packaging DSL block to avoid the packagingOptions warning

## Testing
- ./gradlew help *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d721dc389c832399572ba456b4efc7