### PR TITLE
Set onboarding activity exported

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
 
         <activity
             android:name=".feature.onboarding.OnboardingActivity"
-            android:screenOrientation="portrait">
+            android:screenOrientation="portrait"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
## Summary
- add the missing android:exported attribute to OnboardingActivity to satisfy manifest requirements

## Testing
- `./gradlew assemble` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d7242af8448323a07407f667339dac