### PR TITLE
Add Kotlin version constant to shared dependencies

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -9,6 +9,7 @@ ext {
     roomVersion = '2.6.1'
     navigationVersion = '2.7.7'
     firebaseBomVersion = '33.4.0'
+    kotlinVersion = '1.9.24'
 
     libs = [
             kotlin              : "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",


### PR DESCRIPTION
## Summary
- define a Kotlin version constant in the shared dependencies catalog

## Testing
- ./gradlew help *(fails: Plugin [id: 'com.android.application', version: '8.4.2', apply: false] was not found in any of the following sources)*

------
https://chatgpt.com/codex/tasks/task_e_68d86731fc3c8323847d5eb42221ea2b