### PR TITLE
Add Kotlin KAPT plugin to app build configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android"
+    id "org.jetbrains.kotlin.kapt"
     id "com.google.gms.google-services"
     id "com.google.firebase.crashlytics"
     id "com.google.firebase.firebase-perf"


### PR DESCRIPTION
## Summary
- apply the Kotlin KAPT Gradle plugin in the app module to enable annotation processing support

## Testing
- ./gradlew tasks *(fails: Plugin [id: 'com.android.application', version: '8.4.2', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8673555688323b26369bc198043d0