### PR TITLE
Handle missing secrets gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Baby Guard is a free, offline, and cross-platform application that replaces elec
 | Firebase Cloud Messaging Server Key | FirebaseCloudMessagingServerKey | FIREBASE_CLOUD_MESSAGING_SERVER_KEY |
 
 #### Secrets
-Follow [this guide](https://netguru.atlassian.net/wiki/pages/viewpage.action?pageId=33030753) 
+Follow [this guide](https://netguru.atlassian.net/wiki/pages/viewpage.action?pageId=33030753).
+
+For local development, copy the provided `secret.properties.sample` file to `secret.properties` and replace the placeholder values with the real credentials before building the app.
 
 #### Supported devices
 SDK 21+ (5.0 Lollipop)

--- a/buildsystem/secrets.gradle
+++ b/buildsystem/secrets.gradle
@@ -20,15 +20,21 @@ ext {
         keyConfigPath = "${projectDir.path}/secret.properties"
         File keyConfigFile = file(keyConfigPath)
         keyProps = new Properties();
+        final String placeholderValue = "undefined"
 
         if (keyConfigFile.exists()) {
             keyProps.load(keyConfigFile.newInputStream())
         } else {
-            throw new FileNotFoundException("File $keyConfigPath not found")
+            logger.lifecycle("No secret.properties found at $keyConfigPath. Using placeholder secret values. Copy secret.properties.sample to secret.properties and provide real values when available.")
         }
 
         keyProperty = { var ->
             propNameCase = varToCamelCase(var)
+
+            if (!keyConfigFile.exists()) {
+                return placeholderValue
+            }
+
             prop = keyProps[propNameCase]
             if (prop == null || prop.toString().isEmpty())
                 throw new MissingPropertyException("Missing property $propNameCase")

--- a/secret.properties.sample
+++ b/secret.properties.sample
@@ -1,0 +1,7 @@
+# Copy this file to secret.properties and replace the placeholder values with real secrets.
+# Example:
+# cp secret.properties.sample secret.properties
+# Then edit secret.properties with the actual credentials provided for your environment.
+
+# Firebase Cloud Messaging server key used by the application.
+FirebaseCloudMessagingServerKey=undefined


### PR DESCRIPTION
## Summary
- allow the secrets helper to use placeholder values when `secret.properties` is absent and log setup guidance
- add a `secret.properties.sample` template and document how to copy it in the README

## Testing
- ./gradlew clean build *(fails: could not resolve com.android.application:8.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d86735c3808323a35300c5a5436000